### PR TITLE
add space to sql sentence

### DIFF
--- a/queries.js
+++ b/queries.js
@@ -192,7 +192,7 @@ function getSpacesById(req, res, next) {
 function getSpacesByTown(req, res, next) {
     var town = parseInt(req.params.town);
 
-    db.any('select * from espaciosagenda' +
+    db.any('select * from espaciosagenda ' +
         'where idmuni = $1', town)
         .then(function (data) {
             res.status(200)


### PR DESCRIPTION
Obtener los espacios por municipio, tiraba un error porque faltaba un espacio en la sentencia SQL.